### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,9 +1,9 @@
-CW_Joystick KEYWORD1
-readRaw KEYWORD2
-read KEYWORD2
-convert KEYWORD2
+CW_Joystick	KEYWORD1
+readRaw	KEYWORD2
+read	KEYWORD2
+convert	KEYWORD2
 
-JoyValue KEYWORD1
-joyX KEYWORD2
-joyY KEYWORD2
-joyButton KEYWORD2
+JoyValue	KEYWORD1
+joyX	KEYWORD2
+joyY	KEYWORD2
+joyButton	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords